### PR TITLE
Fix "descriptionmsg"

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -2,7 +2,7 @@
 	"name": "Alexandria",
 	"version": "1.0.0",
 	"namemsg": "skinname-alexandria",
-	"descriptionmsg": "alexandria-skin-desc",
+	"descriptionmsg": "alexandria-desc",
 	"url": "https://www.mediawiki.org/wiki/Skin:Alexandria",
 	"author": [
 		"[https://skins.wmflabs.org skins.wmflabs.org v.1.0]"


### PR DESCRIPTION
Update `descriptionmsg` in `skin.json` to match keys in `i18n/qqq.json` and `i18n/en.json`

FYI: I noticed this issue at: [skins.toolforge.org](https://skins.toolforge.org/wiki/Special:Version#mw-version-skin).

See also:  morags/mediawiki-2018-skin#12.
